### PR TITLE
fix: don't dag.Get in ResolveToLastNode when not needed

### DIFF
--- a/resolver/resolver.go
+++ b/resolver/resolver.go
@@ -55,12 +55,16 @@ func NewBasicResolver(ds ipld.DAGService) *Resolver {
 	}
 }
 
-// ResolveToLastNode walks the given path and returns the ipld.Node
-// referenced by the last element in it.
-func (r *Resolver) ResolveToLastNode(ctx context.Context, fpath path.Path) (ipld.Node, []string, error) {
+// ResolveToLastNode walks the given path and returns the cid of the last node
+// referenced by the path
+func (r *Resolver) ResolveToLastNode(ctx context.Context, fpath path.Path) (*cid.Cid, []string, error) {
 	c, p, err := path.SplitAbsPath(fpath)
 	if err != nil {
 		return nil, nil, err
+	}
+
+	if len(p) == 0 {
+		return c, nil, nil
 	}
 
 	nd, err := r.DAG.Get(ctx, c)
@@ -91,7 +95,7 @@ func (r *Resolver) ResolveToLastNode(ctx context.Context, fpath path.Path) (ipld
 	}
 
 	if len(p) == 0 {
-		return nd, nil, nil
+		return nd.Cid(), nil, nil
 	}
 
 	// Confirm the path exists within the object
@@ -107,7 +111,7 @@ func (r *Resolver) ResolveToLastNode(ctx context.Context, fpath path.Path) (ipld
 	case *ipld.Link:
 		return nil, nil, errors.New("inconsistent ResolveOnce / nd.Resolve")
 	default:
-		return nd, p, nil
+		return nd.Cid(), p, nil
 	}
 }
 

--- a/resolver/resolver_test.go
+++ b/resolver/resolver_test.go
@@ -69,4 +69,40 @@ func TestRecurivePathResolution(t *testing.T) {
 			"recursive path resolution failed for %s: %s != %s",
 			p.String(), key.String(), cKey.String()))
 	}
+
+	rCid, rest, err := resolver.ResolveToLastNode(ctx, p)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(rest) != 0 {
+		t.Error("expected rest to be empty")
+	}
+
+	if rCid.String() != cKey.String() {
+		t.Fatal(fmt.Errorf(
+			"ResolveToLastNode failed for %s: %s != %s",
+			p.String(), rCid.String(), cKey.String()))
+	}
+
+	p2, err := path.FromSegments("/ipfs/", aKey.String())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rCid, rest, err = resolver.ResolveToLastNode(ctx, p2)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+
+	if len(rest) != 0 {
+		t.Error("expected rest to be empty")
+	}
+
+	if rCid.String() != aKey.String() {
+		t.Fatal(fmt.Errorf(
+			"ResolveToLastNode failed for %s: %s != %s",
+			p.String(), rCid.String(), cKey.String()))
+	}
 }


### PR DESCRIPTION
Currently when trying to resolve path that points directly at an 'invalid' block, resolving will fail:
```
Error: failed to decode Protocol Buffers: incorrectly formatted merkledag node: unmarshal failed. proto: illegal wireType 7
```

This is a problem for block coreapi - https://github.com/ipfs/go-ipfs/pull/5331 (it works with this patch applied)