### PR TITLE
gx: update go-cid

### DIFF
--- a/.gx/lastpubver
+++ b/.gx/lastpubver
@@ -1,1 +1,1 @@
-1.0.6: QmPqCBrmkm7jNfYi7xFS7mUZsrN6DEumBMrxLnL7axNJx1
+1.0.7: QmTG5WFmAM4uAnqGskeAPijdpTmmNDLJNCQ71NqfdvC6hV

--- a/package.json
+++ b/package.json
@@ -9,21 +9,21 @@
   "gxDependencies": [
     {
       "author": "why",
-      "hash": "QmXkZeJmx4c3ddjw81DQMUpM1e5LjAack5idzZYWUb2qAJ",
+      "hash": "QmXhrNaxjxNLwAHnWQScc6GxvpJMyn8wfdRmGDbUQwpfth",
       "name": "go-merkledag",
-      "version": "1.0.6"
+      "version": "1.0.7"
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmZtNq8dArGfnpCZfx2pUNY7UcjGhVp5qqwQ4hH6mpTMRQ",
+      "hash": "QmUSyMZ8Vt4vTZr5HdDEgEfpwAXfQRuDdfCFTt7XBzhxpQ",
       "name": "go-ipld-format",
-      "version": "0.5.5"
+      "version": "0.5.6"
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmYVNvtQkeZ6AKSwDrjQTs432QtL6umrrK41EBq3cu7iSP",
+      "hash": "Qmdu2AYUV7yMoVBQPxXNfe7FJcdx16kYtsx6jAPKWQYF1y",
       "name": "go-cid",
-      "version": "0.7.22"
+      "version": "0.7.24"
     },
     {
       "hash": "QmRREK2CAZ5Re2Bd9zZFG6FeYDppUWt5cMgsoUEp3ktgSr",
@@ -36,6 +36,6 @@
   "license": "",
   "name": "go-path",
   "releaseCmd": "git commit -a -m \"gx publish $VERSION\"",
-  "version": "1.0.6"
+  "version": "1.0.7"
 }
 


### PR DESCRIPTION
Depends on:

- https://github.com/libp2p/go-libp2p-kad-dht/pull/186
- https://github.com/ipfs/go-ipld-git/pull/22
- https://github.com/ipfs/go-ipfs-chunker/pull/2
- https://github.com/ipfs/go-ipfs-exchange-offline/pull/4
- https://github.com/libp2p/go-libp2p-routing-helpers/pull/4
- https://github.com/libp2p/go-libp2p-pubsub-router/pull/5


This PR with gx updates has been created using gx-workspace: https://github.com/ipfs/gx-workspace