### PR TITLE
gx: update go-libp2p-routing

### DIFF
--- a/.gx/lastpubver
+++ b/.gx/lastpubver
@@ -1,1 +1,1 @@
-1.1.1: QmX7uSbkNz76yNwBhuwYwRbhihLnJqM73VTCjS3UMJud9A
+1.1.2: Qmc17MNY1xUgiE2nopbi6KATWau9qcGZtdmKKuXvFMVUgc

--- a/package.json
+++ b/package.json
@@ -9,9 +9,9 @@
   "gxDependencies": [
     {
       "author": "why",
-      "hash": "QmXv5mwmQ74r4aiHcNeQ4GAmfB3aWJuqaE4WyDfDfvkgLM",
+      "hash": "QmVB15p7qNVQQGC5RQcAQAovDFaQpRNqorbRwpvdNjHmVC",
       "name": "go-merkledag",
-      "version": "1.1.1"
+      "version": "1.1.2"
     },
     {
       "author": "whyrusleeping",
@@ -36,6 +36,6 @@
   "license": "",
   "name": "go-path",
   "releaseCmd": "git commit -a -m \"gx publish $VERSION\"",
-  "version": "1.1.1"
+  "version": "1.1.2"
 }
 


### PR DESCRIPTION
Depends on:

- https://github.com/libp2p/go-libp2p-kad-dht/pull/199
- https://github.com/ipfs/go-ipfs-routing/pull/14
- https://github.com/libp2p/go-libp2p-routing-helpers/pull/8
- https://github.com/libp2p/go-libp2p-pubsub-router/pull/10
- https://github.com/ipfs/go-bitswap/pull/11
- https://github.com/ipfs/go-blockservice/pull/7
- https://github.com/ipfs/go-merkledag/pull/13


This PR with gx updates has been created using gx-workspace: https://github.com/ipfs/gx-workspace