### PR TITLE
Allow CID functions to work with non-default multibase.

### DIFF
--- a/path.go
+++ b/path.go
@@ -36,8 +36,11 @@ func FromString(s string) Path {
 }
 
 // FromCid safely converts a cid.Cid type to a Path type.
-func FromCid(c cid.Cid) Path {
-	return Path("/ipfs/" + c.String())
+func FromCid(f func(cid.Cid) string, c cid.Cid) Path {
+	if f == nil {
+		f = (cid.Cid).String
+	}
+	return Path("/ipfs/" + f(c))
 }
 
 // Segments returns the different elements of a path
@@ -134,12 +137,12 @@ func ParseCidToPath(txt string) (Path, error) {
 		return "", ErrNoComponents
 	}
 
-	c, err := cid.Decode(txt)
+	_, err := cid.Decode(txt)
 	if err != nil {
 		return "", err
 	}
 
-	return FromCid(c), nil
+	return Path("/ipfs/" + txt), nil
 }
 
 // IsValid checks if a path is a valid ipfs Path.

--- a/resolver/resolver_test.go
+++ b/resolver/resolver_test.go
@@ -95,7 +95,6 @@ func TestRecurivePathResolution(t *testing.T) {
 		t.Fatal(err)
 	}
 
-
 	if len(rest) != 0 {
 		t.Error("expected rest to be empty")
 	}


### PR DESCRIPTION
This:
1. Chaned the `FromCid` function to take a function which translates a Cid to s string.
2. Fixes ParseCidToPath to preserve the original CID string after verifying it is a correct CID.

Yes, (1) is an API change but I greatly prefer it to creating another another tediously named function. This function is not used in many places within `go-ipfs`.  In almost all cases we should be passing in a transformer function anyway, and when we don't have one `nil` can be used instead.  The general idea is we should eventually get the transformer function from the current context which is nearly always available when `FromCid` is used.  A function is used instead of just a multibase encoding for added flexibility, for example we may want to upgrade CidV0 to CidV1.

CC @Stebalien 