### PR TITLE
include the path in path errors

### DIFF
--- a/error.go
+++ b/error.go
@@ -1,0 +1,23 @@
+package path
+
+import (
+	"fmt"
+)
+
+// helper type so path parsing errors include the path
+type pathError struct {
+	error error
+	path  string
+}
+
+func (e *pathError) Error() string {
+	return fmt.Sprintf("invalid path %q: %s", e.path, e.error)
+}
+
+func (e *pathError) Unwrap() error {
+	return e.error
+}
+
+func (e *pathError) Path() string {
+	return e.path
+}

--- a/path_test.go
+++ b/path_test.go
@@ -1,6 +1,7 @@
 package path
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -44,8 +45,8 @@ func TestNoComponents(t *testing.T) {
 		"/ipld/",
 	} {
 		_, err := ParsePath(s)
-		if err != ErrNoComponents {
-			t.Errorf("expected ErrNoComponents, got %s", err)
+		if err == nil || !strings.Contains(err.Error(), "not enough path components") || !strings.Contains(err.Error(), s) {
+			t.Error("wrong error")
 		}
 	}
 }


### PR DESCRIPTION
This should improve UX by telling the user the path we failed to parse.

second half of https://github.com/ipfs/go-ipfs/issues/4190