### PR TITLE
Take fetcher config as parameter to resolver

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/ipfs/go-blockservice v0.1.4
 	github.com/ipfs/go-cid v0.0.7
 	github.com/ipfs/go-datastore v0.4.5
-	github.com/ipfs/go-fetcher v1.2.1-0.20210410011454-571518e2eca7
+	github.com/ipfs/go-fetcher v1.2.1-0.20210419200002-6e0ef2aeedf1
 	github.com/ipfs/go-ipfs-blockstore v0.1.4
 	github.com/ipfs/go-ipfs-exchange-offline v0.0.1
 	github.com/ipfs/go-ipld-cbor v0.0.3
@@ -14,6 +14,9 @@ require (
 	github.com/ipfs/go-log v1.0.4
 	github.com/ipfs/go-merkledag v0.3.2
 	github.com/ipfs/go-unixfsnode v1.1.1
+	github.com/ipld/go-codec-dagpb v1.2.1-0.20210330082435-8ec6b0fbad18
 	github.com/ipld/go-ipld-prime v0.9.1-0.20210402181957-7406578571d1
+	github.com/polydawn/refmt v0.0.0-20201211092308-30ac6d18308e // indirect
 	github.com/stretchr/testify v1.7.0
+	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -154,6 +154,8 @@ github.com/ipfs/go-ds-leveldb v0.4.1/go.mod h1:jpbku/YqBSsBc1qgME8BkWS4AxzF2cEu1
 github.com/ipfs/go-ds-leveldb v0.4.2/go.mod h1:jpbku/YqBSsBc1qgME8BkWS4AxzF2cEu1Ii2r79Hh9s=
 github.com/ipfs/go-fetcher v1.2.1-0.20210410011454-571518e2eca7 h1:237svBHwHi6hAU9ZsMuJBxkyV8hnMAmjMBAvpqouyDQ=
 github.com/ipfs/go-fetcher v1.2.1-0.20210410011454-571518e2eca7/go.mod h1:mlpkadjgVO4a/SW822rtK2b7vIAjtvtw/f6ensvCImI=
+github.com/ipfs/go-fetcher v1.2.1-0.20210419200002-6e0ef2aeedf1 h1:Gb1N44an/HXlxGTzQ30r7ogEqpesaOhTjHltveTrWho=
+github.com/ipfs/go-fetcher v1.2.1-0.20210419200002-6e0ef2aeedf1/go.mod h1:lld7kBIARmpCvhQ/Rob5oOGEKfVjil8L8y4j9jtLdqo=
 github.com/ipfs/go-ipfs-blockstore v0.0.1/go.mod h1:d3WClOmRQKFnJ0Jz/jj/zmksX0ma1gROTlovZKBmN08=
 github.com/ipfs/go-ipfs-blockstore v0.1.0/go.mod h1:5aD0AvHPi7mZc6Ci1WCAhiBQu2IsfTduLl+422H6Rqw=
 github.com/ipfs/go-ipfs-blockstore v0.1.4 h1:2SGI6U1B44aODevza8Rde3+dY30Pb+lbcObe1LETxOQ=

--- a/resolver/resolver.go
+++ b/resolver/resolver.go
@@ -11,11 +11,9 @@ import (
 
 	path "github.com/ipfs/go-path"
 
-	"github.com/ipfs/go-blockservice"
 	cid "github.com/ipfs/go-cid"
 	"github.com/ipfs/go-fetcher"
 	fetcherhelpers "github.com/ipfs/go-fetcher/helpers"
-	bsfetcher "github.com/ipfs/go-fetcher/impl/blockservice"
 	format "github.com/ipfs/go-ipld-format"
 	logging "github.com/ipfs/go-log"
 	"github.com/ipld/go-ipld-prime"
@@ -49,14 +47,13 @@ func (e ErrNoLink) Error() string {
 // TODO: now that this is more modular, try to unify this code with the
 //       the resolvers in namesys
 type Resolver struct {
-	FetchConfig bsfetcher.FetcherConfig
+	FetcherFactory fetcher.Factory
 }
 
 // NewBasicResolver constructs a new basic resolver.
-func NewBasicResolver(bs blockservice.BlockService) *Resolver {
-	fc := bsfetcher.NewFetcherConfig(bs)
+func NewBasicResolver(fetcherFactory fetcher.Factory) *Resolver {
 	return &Resolver{
-		FetchConfig: fc,
+		FetcherFactory: fetcherFactory,
 	}
 }
 
@@ -196,7 +193,7 @@ func (r *Resolver) ResolveLinks(ctx context.Context, ndd ipldp.Node, names []str
 	ctx, cancel := context.WithTimeout(ctx, time.Minute)
 	defer cancel()
 
-	session := r.FetchConfig.NewSession(ctx)
+	session := r.FetcherFactory.NewSession(ctx)
 
 	// traverse selector
 	nodes := []ipldp.Node{ndd}
@@ -218,7 +215,7 @@ func (r *Resolver) resolveNodes(ctx context.Context, c cid.Cid, sel ipld.Node) (
 	ctx, cancel := context.WithTimeout(ctx, time.Minute)
 	defer cancel()
 
-	session := r.FetchConfig.NewSession(ctx)
+	session := r.FetcherFactory.NewSession(ctx)
 
 	// traverse selector
 	lastLink := cid.Undef


### PR DESCRIPTION
# Goals

Avoid constructing a fetcher config in the resolver

# Implementation

Take Fetcher Factory (generalized interface for FetcherConfig) as parameter to the resolver. This removes dependence on the BlockService, which also means not having to reconfigure the FetcherConfig every time you make a resolver. Also, it potentially means we can support Fetchers that are not dependent on the BlockService.
