### PR TITLE
fix(resolver): LookupBySegment to handle list indexes as well as map fields

### DIFF
--- a/resolver/resolver.go
+++ b/resolver/resolver.go
@@ -88,7 +88,7 @@ func (r *Resolver) ResolveToLastNode(ctx context.Context, fpath path.Path) (cid.
 	lastSegment := p[len(p)-1]
 
 	// find final path segment within node
-	nd, err := parent.LookupByString(lastSegment)
+	nd, err := parent.LookupBySegment(ipld.ParsePathSegment(lastSegment))
 	switch err.(type) {
 	case nil:
 	case schema.ErrNoSuchField:


### PR DESCRIPTION
@hannahhoward this one is for you into your branch - handle indexes in paths as well as map fields.

Found via the go-ipfs t0280-plugin-git sharness: `ipfs dag get baf4bcfhzi72pcj5cc4ocz7igcduubuu7aa3cddi/object/parents/0/tree/dir2/hash/f3/hash`
